### PR TITLE
Skip delete if primery key is missing

### DIFF
--- a/src/Database/DBObject.php
+++ b/src/Database/DBObject.php
@@ -317,6 +317,10 @@ class DBObject implements APIObject, \IteratorAggregate
 	{
 		$this->RequireConnection();
 
+		if (empty($this->{$this->GetPrimaryKeyColumn()})) {
+		    return false;
+        }
+
 		$result = DBQuery::Build()->deleteFrom($this->GetTable(), $this->{$this->GetPrimaryKeyColumn()})->Execute();
 
 		return $result;


### PR DESCRIPTION
If primery key is missing delete() wipe out whole table data.